### PR TITLE
Migrate SendbirdChatSDK to 4.0.0

### DIFF
--- a/Apps/AddExtraDataMessageOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/AddExtraDataMessageOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/AddExtraDataMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/AddExtraDataMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/AddExtraDataMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/AddExtraDataMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -208,7 +208,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/AddRemoveOperatorsGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/AddRemoveOperatorsGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/AddRemoveOperatorsGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/AddRemoveOperatorsGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/AddRemoveOperatorsGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/AddRemoveOperatorsGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -201,7 +201,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/AddRemoveOperatorsGroupChannel/Sources/UseCase/AddRemoveOperatorUseCase.swift
+++ b/Apps/AddRemoveOperatorsGroupChannel/Sources/UseCase/AddRemoveOperatorUseCase.swift
@@ -17,10 +17,10 @@ final class AddRemoveOperatorUseCase {
     }
     
     func addOperators(users: [Member], completion: @escaping(Result<Void, SBError>) -> Void) {
-        let userIDs = users.map {
-            $0.userID
+        let userIds = users.map {
+            $0.userId
         }
-        channel.addOperators(userIDs: userIDs) { error in
+        channel.addOperators(userIds: userIds) { error in
             guard let error = error else {
                 completion(.success(()))
                 return
@@ -30,10 +30,10 @@ final class AddRemoveOperatorUseCase {
     }
     
     func removeOperator(users: [Member], completion: @escaping(Result<Void, SBError>) -> Void) {
-        let userIDs = users.map {
-            $0.userID
+        let userIds = users.map {
+            $0.userId
         }
-        channel.removeOperators(userIDs: userIDs) { error in
+        channel.removeOperators(userIds: userIds) { error in
             guard let error = error else {
                 completion(.success(()))
                 return

--- a/Apps/AddStructuredDataMessageOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/AddStructuredDataMessageOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/AddStructuredDataMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/AddStructuredDataMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/AddStructuredDataMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/AddStructuredDataMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -206,7 +206,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/BanUnBanUserGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/BanUnBanUserGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/BanUnBanUserGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/BanUnBanUserGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/BanUnBanUserGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/BanUnBanUserGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/BanUnBanUserGroupChannel/Sources/UseCase/BanAndUnBanUseCase.swift
+++ b/Apps/BanUnBanUserGroupChannel/Sources/UseCase/BanAndUnBanUseCase.swift
@@ -17,7 +17,7 @@ final class BanAndUnBanUseCase {
     }
     
     func ban(user: Member, completion: @escaping(Result<Void, SBError>) -> Void) {
-        channel.banUser(userID: user.userID, seconds: 120, description: nil, completionHandler: { error in
+        channel.banUser(userId: user.userId, seconds: 120, description: nil, completionHandler: { error in
             guard let error = error else {
                 completion(.success(()))
                 return
@@ -27,7 +27,7 @@ final class BanAndUnBanUseCase {
     }
     
     func unBan(user: Member, completion: @escaping(Result<Void, SBError>) -> Void) {
-        channel.unbanUser(userID: user.userID, completionHandler: { error in
+        channel.unbanUser(userId: user.userId, completionHandler: { error in
             guard let error = error else {
                 completion(.success(()))
                 return

--- a/Apps/BasicGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/BasicGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/BasicGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/BasicGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/BasicGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/BasicGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/BasicOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/BasicOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/BasicOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/BasicOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/BasicOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/BasicOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -206,7 +206,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/CategorizeMessageGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/CategorizeMessageGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/CategorizeMessageGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/CategorizeMessageGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/CategorizeMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/CategorizeMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/CategorizeMessageOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/CategorizeMessageOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/CategorizeMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/CategorizeMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/CategorizeMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/CategorizeMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -206,7 +206,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/CategorizeWithCustomTypeGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/CategorizeWithCustomTypeGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/CategorizeWithCustomTypeGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/CategorizeWithCustomTypeGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/CategorizeWithCustomTypeGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/CategorizeWithCustomTypeGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/CategorizeWithCustomTypeGroupChannel/Sources/UseCase/CreateWithCategoryGroupChannelUseCase.swift
+++ b/Apps/CategorizeWithCustomTypeGroupChannel/Sources/UseCase/CreateWithCategoryGroupChannelUseCase.swift
@@ -27,8 +27,8 @@ final class CreateWithCategoryGroupChannelUseCase {
         params.addUsers(users)
         params.name = channelName
         
-        if let operatorUserId = SendbirdChat.getCurrentUser()?.userID {
-            params.operatorUserIDs = [operatorUserId]
+        if let operatorUserId = SendbirdChat.getCurrentUser()?.userId {
+            params.operatorUserIds = [operatorUserId]
         }
         
         GroupChannel.createChannel(params: params) { channel, error in

--- a/Apps/CategorizeWithCustomTypeOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/CategorizeWithCustomTypeOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/CategorizeWithCustomTypeOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/CategorizeWithCustomTypeOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/CategorizeWithCustomTypeOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/CategorizeWithCustomTypeOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -206,7 +206,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/CategorizeWithCustomTypeOpenChannel/Sources/UseCase/CreateWithCategoryOpenChannelUseCase.swift
+++ b/Apps/CategorizeWithCustomTypeOpenChannel/Sources/UseCase/CreateWithCategoryOpenChannelUseCase.swift
@@ -13,7 +13,7 @@ class CreateWithCategoryOpenChannelUseCase {
     
     func createOpenChannel(channelName: String?, imageData: Data?, completion: @escaping (Result<OpenChannel, SBError>) -> Void) {
         let params = OpenChannelCreateParams()
-        params.operatorUserIDs = [SendbirdChat.getCurrentUser()?.userID].compactMap { $0 }
+        params.operatorUserIds = [SendbirdChat.getCurrentUser()?.userId].compactMap { $0 }
         let random = Int.random(in: 0...3)
         let customTypes = ["School", "Music", "Contacts", "People"]
         params.customType = customTypes[random]

--- a/Apps/ChannelTypesGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/ChannelTypesGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/ChannelTypesGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/ChannelTypesGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/ChannelTypesGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/ChannelTypesGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/ChannelTypesGroupChannel/Sources/UseCase/CreateGroupChannelWithTypeUseCase.swift
+++ b/Apps/ChannelTypesGroupChannel/Sources/UseCase/CreateGroupChannelWithTypeUseCase.swift
@@ -33,8 +33,8 @@ class CreateGroupChannelWithTypeUseCase {
             params.isSuper = true
         }
         
-        if let operatorUserId = SendbirdChat.getCurrentUser()?.userID {
-            params.operatorUserIDs = [operatorUserId]
+        if let operatorUserId = SendbirdChat.getCurrentUser()?.userId {
+            params.operatorUserIds = [operatorUserId]
         }
         
         GroupChannel.createChannel(params: params) { channel, error in

--- a/Apps/CopyMessageOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/CopyMessageOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/CopyMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/CopyMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/CopyMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/CopyMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -239,7 +239,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/DeleteMessageOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/DeleteMessageOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/DeleteMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/DeleteMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/DeleteMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/DeleteMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -208,7 +208,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/DeleteMessageOpenChannel/Sources/UseCase/DeleteMessageUseCase.swift
+++ b/Apps/DeleteMessageOpenChannel/Sources/UseCase/DeleteMessageUseCase.swift
@@ -35,7 +35,7 @@ final class DeleteMessageUseCase {
 }
 
 extension DeleteMessageUseCase: OpenChannelDelegate {
-    func channel(_ channel: BaseChannel, messageWasDeleted messageID: Int64) {
+    func channel(_ channel: BaseChannel, messageWasDeleted messageId: Int64) {
         // Refresh or show indicator that message been deleted
     }
 }

--- a/Apps/FreezeUnFreezeGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/FreezeUnFreezeGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/FreezeUnFreezeGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/FreezeUnFreezeGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/FreezeUnFreezeGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/FreezeUnFreezeGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/GenerateThumbnailForFileOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/GenerateThumbnailForFileOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/GenerateThumbnailForFileOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/GenerateThumbnailForFileOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/GenerateThumbnailForFileOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/GenerateThumbnailForFileOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -206,7 +206,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/GenerateThumbnailForFileOpenChannel/Sources/UseCase/GenerateThumbnailFileMessageUseCase.swift
+++ b/Apps/GenerateThumbnailForFileOpenChannel/Sources/UseCase/GenerateThumbnailFileMessageUseCase.swift
@@ -50,20 +50,20 @@ class GenerateThumbnailFileMessageUseCase {
             
             guard let message = message else { return }
             
-            self?.cachedDatasForResending.removeValue(forKey: message.requestID)
+            self?.cachedDatasForResending.removeValue(forKey: message.requestId)
             
             completion(.success(message))
         }
         
-        if let requestID = fileMessage?.requestID {
-            cachedDatasForResending[requestID] = mediaFile.data
+        if let requestId = fileMessage?.requestId {
+            cachedDatasForResending[requestId] = mediaFile.data
         }
             
         return fileMessage
     }
     
     open func resendMessage(_ message: FileMessage, completion: @escaping (Result<BaseMessage, SBError>) -> Void) {
-        guard let binaryData = cachedDatasForResending[message.requestID] else { return }
+        guard let binaryData = cachedDatasForResending[message.requestId] else { return }
         
         channel.resendFileMessage(message, binaryData: binaryData) { message, error in
             if let error = error {

--- a/Apps/HideOrArchiveGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/HideOrArchiveGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/HideOrArchiveGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/HideOrArchiveGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/HideOrArchiveGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/HideOrArchiveGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/HideOrArchiveGroupChannel/Sources/UseCase/HideArchiveChannelListUsecase.swift
+++ b/Apps/HideOrArchiveGroupChannel/Sources/UseCase/HideArchiveChannelListUsecase.swift
@@ -64,10 +64,11 @@ class HideArchiveChannelListUsecase: NSObject {
     }
         
     func createGroupChannelListCollection() -> GroupChannelCollection? {
-        let channelListQuery = GroupChannel.createMyGroupChannelListQuery()
-        channelListQuery.order = .latestLastMessage
-        channelListQuery.limit = 20
-        channelListQuery.channelHiddenStateFilter = .hiddenOnly
+        let channelListQuery = GroupChannel.createMyGroupChannelListQuery {
+            $0.order = .latestLastMessage
+            $0.limit = 20
+            $0.channelHiddenStateFilter = .hiddenOnly
+        }
         
         let collection = SendbirdChat.createGroupChannelCollection(query: channelListQuery)
         collection?.delegate = self

--- a/Apps/LocalCachingGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/LocalCachingGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/LocalCachingGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/LocalCachingGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/LocalCachingGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/LocalCachingGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: LocalCachingMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/LocalCachingGroupChannel/Sources/UseCase/LocalCachingMessageListUseCase.swift
+++ b/Apps/LocalCachingGroupChannel/Sources/UseCase/LocalCachingMessageListUseCase.swift
@@ -153,8 +153,8 @@ class LocalCachingMessageListUseCase: NSObject {
     private func replaceMessages(_ newMessages: [BaseMessage]) {
         newMessages.forEach { newMessage in
             if let index = messages.firstIndex(where: {
-                $0.messageID == newMessage.messageID
-                || $0.requestID == newMessage.requestID
+                $0.messageId == newMessage.messageId
+                || $0.requestId == newMessage.requestId
             }) {
                 messages[index] = newMessage
             }
@@ -187,7 +187,7 @@ extension LocalCachingMessageListUseCase: MessageCollectionDelegate {
         switch context.sendingStatus {
         case .succeeded:
             self.messages = self.messages.filter { oldMessage in
-                deletedMessages.map { $0.messageID }.contains(oldMessage.messageID) == false
+                deletedMessages.map { $0.messageId }.contains(oldMessage.messageId) == false
             }
         case .failed:
             // Remove the failed message from your data source.

--- a/Apps/MarkAsReadGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/MarkAsReadGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MarkAsReadGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/MarkAsReadGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/MarkAsReadGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/MarkAsReadGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -221,7 +221,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/MembersReadMessageGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/MembersReadMessageGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MembersReadMessageGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/MembersReadMessageGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/MembersReadMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/MembersReadMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -205,7 +205,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/MembersUnReadMessageGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/MembersUnReadMessageGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MembersUnReadMessageGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/MembersUnReadMessageGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/MembersUnReadMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/MembersUnReadMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -205,7 +205,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/MentionUsersInMessageGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/MentionUsersInMessageGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MentionUsersInMessageGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/MentionUsersInMessageGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/MentionUsersInMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/MentionUsersInMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -204,7 +204,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/MentionUsersInMessageGroupChannel/Sources/Channel/MentionedUserMessageCell.swift
+++ b/Apps/MentionUsersInMessageGroupChannel/Sources/Channel/MentionedUserMessageCell.swift
@@ -40,7 +40,7 @@ class MentionedUserMessageCell: BasicMessageCell {
     ) {
         configure(with: message)
         let userNames: [String] = message.mentionedUsers.map {
-            $0.nickname ?? $0.userID
+            $0.nickname ?? $0.userId
         }
         usersLabel.text = userNames.joined(separator: ",")
     }

--- a/Apps/MentionUsersInMessageGroupChannel/Sources/UseCase/MentionUsersInMessageUseCase.swift
+++ b/Apps/MentionUsersInMessageGroupChannel/Sources/UseCase/MentionUsersInMessageUseCase.swift
@@ -18,7 +18,7 @@ class MentionUsersInMessageUseCase {
 
     func sendMessage(_ message: String, mentionedUsers: [User], completion: @escaping (Result<UserMessage, SBError>) -> Void) -> UserMessage? {
         let userParams = UserMessageCreateParams(message: message)
-        userParams.mentionedUserIDs = mentionedUsers.map({
+        userParams.mentionedUserIds = mentionedUsers.map({
             return $0.userId
         })
         userParams.mentionType = .users

--- a/Apps/MentionUsersInMessageGroupChannel/Sources/UseCase/MentionUsersInMessageUseCase.swift
+++ b/Apps/MentionUsersInMessageGroupChannel/Sources/UseCase/MentionUsersInMessageUseCase.swift
@@ -19,7 +19,7 @@ class MentionUsersInMessageUseCase {
     func sendMessage(_ message: String, mentionedUsers: [User], completion: @escaping (Result<UserMessage, SBError>) -> Void) -> UserMessage? {
         let userParams = UserMessageCreateParams(message: message)
         userParams.mentionedUserIDs = mentionedUsers.map({
-            return $0.userID
+            return $0.userId
         })
         userParams.mentionType = .users
         return channel.sendUserMessage(params: userParams, completionHandler: { message, error in

--- a/Apps/MentionUsersInMessageOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/MentionUsersInMessageOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MentionUsersInMessageOpenChannel/Sources/Channel/MentionedUserMessageCell.swift
+++ b/Apps/MentionUsersInMessageOpenChannel/Sources/Channel/MentionedUserMessageCell.swift
@@ -40,7 +40,7 @@ class MentionedUserMessageCell: BasicMessageCell {
     ) {
         configure(with: message)
         let userNames: [String] = message.mentionedUsers.map {
-            $0.nickname ?? $0.userID
+            $0.nickname ?? $0.userId
         }
         usersLabel.text = userNames.joined(separator: ",")
     }

--- a/Apps/MentionUsersInMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/MentionUsersInMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/MentionUsersInMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/MentionUsersInMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -208,7 +208,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/MentionUsersInMessageOpenChannel/Sources/UseCase/MentionUsersInMessageUseCase.swift
+++ b/Apps/MentionUsersInMessageOpenChannel/Sources/UseCase/MentionUsersInMessageUseCase.swift
@@ -18,7 +18,7 @@ class MentionUsersInMessageUseCase {
 
     func sendMessage(_ message: String, mentionedUsers: [User], completion: @escaping (Result<UserMessage, SBError>) -> Void) -> UserMessage? {
         let userParams = UserMessageCreateParams(message: message)
-        userParams.mentionedUserIDs = mentionedUsers.map({
+        userParams.mentionedUserIds = mentionedUsers.map({
             return $0.userId
         })
         userParams.mentionType = .users

--- a/Apps/MentionUsersInMessageOpenChannel/Sources/UseCase/MentionUsersInMessageUseCase.swift
+++ b/Apps/MentionUsersInMessageOpenChannel/Sources/UseCase/MentionUsersInMessageUseCase.swift
@@ -19,7 +19,7 @@ class MentionUsersInMessageUseCase {
     func sendMessage(_ message: String, mentionedUsers: [User], completion: @escaping (Result<UserMessage, SBError>) -> Void) -> UserMessage? {
         let userParams = UserMessageCreateParams(message: message)
         userParams.mentionedUserIDs = mentionedUsers.map({
-            return $0.userID
+            return $0.userId
         })
         userParams.mentionType = .users
         return channel.sendUserMessage(params: userParams, completionHandler: { message, error in

--- a/Apps/MessageThreadingGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/MessageThreadingGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MessageThreadingGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/MessageThreadingGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -204,7 +204,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/MessageThreadingGroupChannel/Sources/UseCase/ReplyToMessageUseCase.swift
+++ b/Apps/MessageThreadingGroupChannel/Sources/UseCase/ReplyToMessageUseCase.swift
@@ -18,7 +18,7 @@ class ReplyToMessageUseCase {
     
     func replyToMessage(_ message: BaseMessage, reply: String, completion: @escaping (Result<UserMessage, SBError>) -> Void) {
         let params = UserMessageCreateParams(message: reply)
-        params.parentMessageID = message.messageID
+        params.parentMessageID = message.messageId
         
         channel.sendUserMessage(params: params) { message, error in
             if let error = error {

--- a/Apps/MessageThreadingGroupChannel/Sources/UseCase/ReplyToMessageUseCase.swift
+++ b/Apps/MessageThreadingGroupChannel/Sources/UseCase/ReplyToMessageUseCase.swift
@@ -18,7 +18,7 @@ class ReplyToMessageUseCase {
     
     func replyToMessage(_ message: BaseMessage, reply: String, completion: @escaping (Result<UserMessage, SBError>) -> Void) {
         let params = UserMessageCreateParams(message: reply)
-        params.parentMessageID = message.messageId
+        params.parentMessageId = message.messageId
         
         channel.sendUserMessage(params: params) { message, error in
             if let error = error {

--- a/Apps/MessageThreadingOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/MessageThreadingOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MessageThreadingOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/MessageThreadingOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -208,7 +208,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/MessageThreadingOpenChannel/Sources/UseCase/ReplyToMessageUseCase.swift
+++ b/Apps/MessageThreadingOpenChannel/Sources/UseCase/ReplyToMessageUseCase.swift
@@ -18,7 +18,7 @@ class ReplyToMessageUseCase {
     
     func replyToMessage(_ message: BaseMessage, reply: String, completion: @escaping (Result<UserMessage, SBError>) -> Void) -> UserMessage? {
         let params = UserMessageCreateParams(message: reply)
-        params.parentMessageID = message.messageId
+        params.parentMessageId = message.messageId
         
         return channel.sendUserMessage(params: params) { message, error in
             if let error = error {

--- a/Apps/MessageThreadingOpenChannel/Sources/UseCase/ReplyToMessageUseCase.swift
+++ b/Apps/MessageThreadingOpenChannel/Sources/UseCase/ReplyToMessageUseCase.swift
@@ -18,7 +18,7 @@ class ReplyToMessageUseCase {
     
     func replyToMessage(_ message: BaseMessage, reply: String, completion: @escaping (Result<UserMessage, SBError>) -> Void) -> UserMessage? {
         let params = UserMessageCreateParams(message: reply)
-        params.parentMessageID = message.messageID
+        params.parentMessageID = message.messageId
         
         return channel.sendUserMessage(params: params) { message, error in
             if let error = error {

--- a/Apps/MessageUndeliveredCountGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/MessageUndeliveredCountGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MessageUndeliveredCountGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/MessageUndeliveredCountGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/MessageUndeliveredCountGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/MessageUndeliveredCountGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -207,7 +207,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/MessageUndeliveredCountGroupChannel/Sources/MessageStatusCell/MessageUndeliveredStatusCell.swift
+++ b/Apps/MessageUndeliveredCountGroupChannel/Sources/MessageStatusCell/MessageUndeliveredStatusCell.swift
@@ -39,8 +39,8 @@ class MessageUndeliveredStatusCell: BasicMessageCell {
         undeliveredCountUseCase: MessageUndeliveredMembersCountUseCase
     ) {
         configure(with: message)
-        let currentUserId = UserConnectionUseCase.shared.currentUser?.userID
-        if message.sender?.userID == currentUserId {
+        let currentUserId = UserConnectionUseCase.shared.currentUser?.userId
+        if message.sender?.userId == currentUserId {
             unReadStatusLabel.isHidden = false
             unReadStatusLabel.text = undeliveredCountUseCase.getUndeliveredMessageStatus(for: message)
         } else {

--- a/Apps/MetaDataCounterOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/MetaDataCounterOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MetaDataCounterOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/MetaDataCounterOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else {
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else {
             return
         }
         

--- a/Apps/MetaDataCounterOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/MetaDataCounterOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -223,7 +223,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/MuteAndUnMuteUsersGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/MuteAndUnMuteUsersGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MuteAndUnMuteUsersGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/MuteAndUnMuteUsersGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/MuteAndUnMuteUsersGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/MuteAndUnMuteUsersGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -201,7 +201,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/MuteAndUnMuteUsersGroupChannel/Sources/UseCase/MuteAndUnmuteUseCase.swift
+++ b/Apps/MuteAndUnMuteUsersGroupChannel/Sources/UseCase/MuteAndUnmuteUseCase.swift
@@ -17,7 +17,7 @@ final class MuteAndUnmuteUseCase {
     }
     
     func mute(user: Member, completion: @escaping(Result<Void, SBError>) -> Void) {
-        channel.muteUser(userID: user.userID, seconds: 120, description: nil, completionHandler: { error in
+        channel.muteUser(userId: user.userId, seconds: 120, description: nil, completionHandler: { error in
             guard let error = error else {
                 completion(.success(()))
                 return
@@ -27,7 +27,7 @@ final class MuteAndUnmuteUseCase {
     }
     
     func Unmute(user: Member, completion: @escaping(Result<Void, SBError>) -> Void) {
-        channel.unmuteUser(userID: user.userID, completionHandler: { error in
+        channel.unmuteUser(userId: user.userId, completionHandler: { error in
             guard let error = error else {
                 completion(.success(()))
                 return

--- a/Apps/MutedAndBannedUsersListGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/MutedAndBannedUsersListGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/MutedAndBannedUsersListGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/MutedAndBannedUsersListGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/MutedAndBannedUsersListGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/MutedAndBannedUsersListGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/MutedAndBannedUsersListGroupChannel/Sources/UseCase /BannedMembersListUseCase.swift
+++ b/Apps/MutedAndBannedUsersListGroupChannel/Sources/UseCase /BannedMembersListUseCase.swift
@@ -23,8 +23,9 @@ class BannedMembersListUseCase {
     private let channel: GroupChannel
     
     private lazy var membersListQuery: BannedUserListQuery? = {
-        let query = channel.createBannedUserListQuery()
-        query?.limit = 10
+        let params = BannedUserListQueryParams()
+        params.limit = 10
+        let query = channel.createBannedUserListQuery(params: params)
         return query
     }()
     

--- a/Apps/MutedAndBannedUsersListGroupChannel/Sources/UseCase /MutedMembersListUseCase.swift
+++ b/Apps/MutedAndBannedUsersListGroupChannel/Sources/UseCase /MutedMembersListUseCase.swift
@@ -23,8 +23,9 @@ class MutedMembersListUseCase {
     private let channel: GroupChannel
     
     private lazy var membersListQuery: MutedUserListQuery? = {
-        let query = channel.createMutedUserListQuery()
-        query?.limit = 10
+        let query = channel.createMutedUserListQuery {
+            $0.limit = 10
+        }
         return query
     }()
     

--- a/Apps/OpenGraphTagsGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/OpenGraphTagsGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/OpenGraphTagsGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/OpenGraphTagsGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/OpenGraphTagsGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/OpenGraphTagsGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/OpenGraphTagsOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/OpenGraphTagsOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/OpenGraphTagsOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/OpenGraphTagsOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/OpenGraphTagsOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/OpenGraphTagsOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -206,7 +206,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/OperatorsListGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/OperatorsListGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/OperatorsListGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/OperatorsListGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/OperatorsListGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/OperatorsListGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/OrderedMembersOperatorsGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/OrderedMembersOperatorsGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/OrderedMembersOperatorsGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/OrderedMembersOperatorsGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/OrderedMembersOperatorsGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/OrderedMembersOperatorsGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/OrderedMembersOperatorsGroupChannel/Sources/UseCase/OrderedMemberOperatorsUseCase.swift
+++ b/Apps/OrderedMembersOperatorsGroupChannel/Sources/UseCase/OrderedMemberOperatorsUseCase.swift
@@ -22,10 +22,11 @@ class OrderedMemberOperatorsUseCase {
     
     private let channel: GroupChannel
     
-    private lazy var membersListQuery: GroupChannelMemberListQuery? = {
-        let query = channel.createMemberListQuery()
-        query?.limit = 10
-        query?.order = .operatorThenMemberNicknameAlphabetical
+    private lazy var membersListQuery: MemberListQuery? = {
+        let query = channel.createMemberListQuery {
+            $0.limit = 10
+            $0.order = .operatorThenMemberNicknameAlphabetical
+        }
         return query
     }()
     

--- a/Apps/PushNotificationsGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/PushNotificationsGroupChannel/Sources/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.backgroundColor = .systemBackground

--- a/Apps/PushNotificationsGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/PushNotificationsGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/PushNotificationsGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/PushNotificationsGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.backgroundColor = .systemBackground

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/UserConnectionUseCase.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/UserConnectionUseCase.swift
@@ -17,7 +17,7 @@ public class UserConnectionUseCase {
     public private(set) var isAutoLogin: Bool
     
     @UserDefault(key: "sendbird_user_id", defaultValue: nil)
-    public private(set) var userID: String?
+    public private(set) var userId: String?
     
     public var currentUser: User? {
         SendbirdChat.getCurrentUser()
@@ -27,9 +27,9 @@ public class UserConnectionUseCase {
         
     private init() { }
     
-    public func login(userID: String,
+    public func login(userId: String,
                       completion: @escaping (Result<User, SBError>) -> Void) {
-        SendbirdChat.connect(userID: userID) { [weak self] user, error in
+        SendbirdChat.connect(userId: userId) { [weak self] user, error in
             if let error = error {
                 completion(.failure(error))
                 return
@@ -94,7 +94,7 @@ public class UserConnectionUseCase {
     }
         
     private func storeUserInfo(_ user: User) {
-        userID = user.userID
+        userId = user.userId
         isAutoLogin = true
     }
             

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/UserLoginViewController.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/UserLoginViewController.swift
@@ -114,7 +114,7 @@ public final class UserLoginViewController: UIViewController {
             
             switch result {
             case .success(let user):
-                if user.nickname?.isEmpty ?? true {
+                if user.nickname.isEmpty {
                     self?.presentEditViewController(user: user)
                 } else {
                     self?.didConnectUser(user)

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/UserLoginViewController.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/UserLoginViewController.swift
@@ -15,22 +15,22 @@ public final class UserLoginViewController: UIViewController {
     
     private let didConnectUser: DidConnectUserHandler
     
-    private lazy var userIDLabel: UILabel = {
-        let userIDLabel: UILabel = UILabel()
-        userIDLabel.text = "USER ID"
-        userIDLabel.font = .boldSystemFont(ofSize: 13)
-        userIDLabel.textColor = .secondaryLabel
-        return userIDLabel
+    private lazy var userIdLabel: UILabel = {
+        let userIdLabel: UILabel = UILabel()
+        userIdLabel.text = "USER ID"
+        userIdLabel.font = .boldSystemFont(ofSize: 13)
+        userIdLabel.textColor = .secondaryLabel
+        return userIdLabel
     }()
     
-    private lazy var userIDTextField: UITextField = {
-        let userIDTextField = UITextField()
-        userIDTextField.placeholder = "USER ID"
-        userIDTextField.font = .systemFont(ofSize: 24)
-        userIDTextField.textColor = .label
-        userIDTextField.tintColor = .systemPurple
-        userIDTextField.borderStyle = .roundedRect
-        return userIDTextField
+    private lazy var userIdTextField: UITextField = {
+        let userIdTextField = UITextField()
+        userIdTextField.placeholder = "USER ID"
+        userIdTextField.font = .systemFont(ofSize: 24)
+        userIdTextField.textColor = .label
+        userIdTextField.tintColor = .systemPurple
+        userIdTextField.borderStyle = .roundedRect
+        return userIdTextField
     }()
     
     private lazy var connectButton: UIButton = {
@@ -60,26 +60,26 @@ public final class UserLoginViewController: UIViewController {
     }
     
     private func setupSubviews() {
-        view.addSubview(userIDLabel)
-        userIDLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(userIdLabel)
+        userIdLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            userIDLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30),
-            userIDLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            userIDLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
+            userIdLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30),
+            userIdLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            userIdLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
         ])
         
-        view.addSubview(userIDTextField)
-        userIDTextField.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(userIdTextField)
+        userIdTextField.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            userIDTextField.topAnchor.constraint(equalTo: userIDLabel.bottomAnchor, constant: 5),
-            userIDTextField.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            userIDTextField.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
+            userIdTextField.topAnchor.constraint(equalTo: userIdLabel.bottomAnchor, constant: 5),
+            userIdTextField.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            userIdTextField.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
         ])
         
         view.addSubview(connectButton)
         connectButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            connectButton.topAnchor.constraint(equalTo: userIDTextField.bottomAnchor, constant: 30),
+            connectButton.topAnchor.constraint(equalTo: userIdTextField.bottomAnchor, constant: 30),
             connectButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
             connectButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             connectButton.heightAnchor.constraint(equalToConstant: 50)
@@ -87,8 +87,8 @@ public final class UserLoginViewController: UIViewController {
     }
     
     private func loadCachedUser() {
-        if let userID = UserConnectionUseCase.shared.userID {
-            userIDTextField.text = userID
+        if let userId = UserConnectionUseCase.shared.userId {
+            userIdTextField.text = userId
         }
         
         if UserConnectionUseCase.shared.isAutoLogin {
@@ -100,8 +100,8 @@ public final class UserLoginViewController: UIViewController {
         view.endEditing(true)
         
         guard
-            let userID = userIDTextField.text,
-            validateText(userID: userID)
+            let userId = userIdTextField.text,
+            validateText(userId: userId)
         else {
             presentAlert(title: "Error", message: "User ID and Nickname are required.")
             return
@@ -109,7 +109,7 @@ public final class UserLoginViewController: UIViewController {
         
         updateUIForConnecting()
         
-        UserConnectionUseCase.shared.login(userID: userID) { [weak self] result in
+        UserConnectionUseCase.shared.login(userId: userId) { [weak self] result in
             self?.updateUIForDefault()
             
             switch result {
@@ -135,18 +135,18 @@ public final class UserLoginViewController: UIViewController {
         present(navigation, animated: true)
     }
     
-    private func validateText(userID: String) -> Bool {
-        userID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+    private func validateText(userId: String) -> Bool {
+        userId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }
     
     private func updateUIForDefault() {
-        userIDTextField.isEnabled = true
+        userIdTextField.isEnabled = true
         connectButton.isEnabled = true
         connectButton.setTitle("Connect", for: .normal)
     }
 
     private func updateUIForConnecting() {
-        userIDTextField.isEnabled = false
+        userIdTextField.isEnabled = false
         connectButton.isEnabled = false
         connectButton.setTitle("Connecting...", for: .normal)
     }
@@ -163,7 +163,7 @@ public final class UserLoginViewController: UIViewController {
 extension UserLoginViewController: UITextFieldDelegate {
     
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if textField == userIDTextField {
+        if textField == userIdTextField {
             connectUser()
             textField.resignFirstResponder()
         }

--- a/Apps/ReactToMessageGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/ReactToMessageGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/ReactToMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/ReactToMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -204,7 +204,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/ReportMessageUserGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/ReportMessageUserGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/ReportMessageUserGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/ReportMessageUserGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else {
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else {
             presentReportingMessageAlert(for: message)
             return
         }
@@ -33,7 +33,7 @@ extension GroupChannelViewController {
         )
         
         let user = message.sender
-        let reportUserString = String(format: "Report %@", user?.userID ?? "User")
+        let reportUserString = String(format: "Report %@", user?.userId ?? "User")
         alert.addAction(
             UIAlertAction(title: reportUserString, style: .destructive) { [weak self] _ in
                 guard let user = user else { return }

--- a/Apps/ReportMessageUserGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/ReportMessageUserGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -196,7 +196,7 @@ extension GroupChannelViewController: UITableViewDelegate {
 
 extension GroupChannelViewController: ReportMessageUserUseCaseDelegate {
     func reportMessageUserUseCase(_ useCase: ReportMessageUserUseCase, didSuccessReporting user: User) {
-        presentAlert(title: "Success", message: String(format: "%@ successfully reported", user.userID), closeHandler: nil)
+        presentAlert(title: "Success", message: String(format: "%@ successfully reported", user.userId), closeHandler: nil)
     }
     
     func reportMessageUserUseCase(_ useCase: ReportMessageUserUseCase, didFailedReporting error: SBError) {
@@ -229,7 +229,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/ReportMessageUserOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/ReportMessageUserOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/ReportMessageUserOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/ReportMessageUserOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else {
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else {
             presentReportingMessageAlert(for: message)
             return
         }
@@ -33,7 +33,7 @@ extension OpenChannelViewController {
         )
         
         let user = message.sender
-        let reportUserString = String(format: "Report %@", user?.userID ?? "User")
+        let reportUserString = String(format: "Report %@", user?.userId ?? "User")
         alert.addAction(
             UIAlertAction(title: reportUserString, style: .destructive) { [weak self] _ in
                 guard let user = user else { return }
@@ -79,7 +79,7 @@ extension OpenChannelViewController {
         )
         
         let user = message.sender
-        let reportUserString = String(format: "Report %@", user?.userID ?? "User")
+        let reportUserString = String(format: "Report %@", user?.userId ?? "User")
         alert.addAction(
             UIAlertAction(title: reportUserString, style: .destructive) { [weak self] _ in
                 guard let user = user else { return }

--- a/Apps/ReportMessageUserOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/ReportMessageUserOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -189,7 +189,7 @@ extension OpenChannelViewController: UITableViewDelegate {
 
 extension OpenChannelViewController: ReportMessageUserUseCaseDelegate {
     func reportMessageUserUseCase(_ useCase: ReportMessageUserUseCase, didSuccessReporting user: User) {
-        presentAlert(title: "Success", message: String(format: "%@ successfully reported", user.userID), closeHandler: nil)
+        presentAlert(title: "Success", message: String(format: "%@ successfully reported", user.userId), closeHandler: nil)
     }
     
     func reportMessageUserUseCase(_ useCase: ReportMessageUserUseCase, didFailedReporting error: SBError) {
@@ -232,7 +232,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/SendVariousTypesOfFileOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/SendVariousTypesOfFileOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/SendVariousTypesOfFileOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/SendVariousTypesOfFileOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/SendVariousTypesOfFileOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/SendVariousTypesOfFileOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -206,7 +206,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/TrackFileUploadAndCancelGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/TrackFileUploadAndCancelGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/TrackFileUploadAndCancelGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/TrackFileUploadAndCancelGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/TrackFileUploadAndCancelGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/TrackFileUploadAndCancelGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -220,7 +220,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/TrackFileUploadAndCancelGroupChannel/Sources/UseCase/TrackAndCancelFileUploadUseCase.swift
+++ b/Apps/TrackFileUploadAndCancelGroupChannel/Sources/UseCase/TrackAndCancelFileUploadUseCase.swift
@@ -43,7 +43,7 @@ class TrackAndCancelFileUploadUseCase: GroupChannelFileMessageUseCase {
         fileMessageParams.mimeType = mediaFile.mimeType
         fileMessageParams.thumbnailSizes = [.make(maxWidth: 320.0, maxHeight: 320.0)]
         
-        currentFileMessage = channel.sendFileMessage(params: fileMessageParams) { [weak self] requestID, bytesSent, totalBytesSent, totalBytesExpectedToSend in
+        currentFileMessage = channel.sendFileMessage(params: fileMessageParams) { [weak self] requestId, bytesSent, totalBytesSent, totalBytesExpectedToSend in
             guard let self = self else { return }
             let uploadProgress: Float = Float(totalBytesSent) / Float(totalBytesExpectedToSend)
             self.delegate?.trackAndCancelFileUploadUseCase(self, fileProgress: uploadProgress)
@@ -57,25 +57,25 @@ class TrackAndCancelFileUploadUseCase: GroupChannelFileMessageUseCase {
             
             guard let message = message, let self = self else { return }
             
-            self.cachedDatasForResending.removeValue(forKey: message.requestID)
+            self.cachedDatasForResending.removeValue(forKey: message.requestId)
             
             completion(.success(message))
             
             self.delegate?.trackAndCancelFileUploadUseCase(self, didSuccessUploadMessage: message)
         }
         
-        if let requestID = currentFileMessage?.requestID {
-            cachedDatasForResending[requestID] = mediaFile.data
+        if let requestId = currentFileMessage?.requestId {
+            cachedDatasForResending[requestId] = mediaFile.data
         }
         self.delegate?.trackAndCancelFileUploadUseCase(self, willUploadMessage: currentFileMessage)
         return currentFileMessage
     }
     
     func cancelUpload() {
-        guard let requestId = currentFileMessage?.requestID else {
+        guard let requestId = currentFileMessage?.requestId else {
             return
         }
-        GroupChannel.cancelUploadingFileMessage(requestID: requestId) { result, error in
+        GroupChannel.cancelUploadingFileMessage(requestId: requestId) { result, error in
             // Handle error and success
         }
     }

--- a/Apps/TypingIndicatorGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/TypingIndicatorGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/TypingIndicatorGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/TypingIndicatorGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/TypingIndicatorGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/TypingIndicatorGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -242,7 +242,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/TypingIndicatorGroupChannel/Sources/UseCase/GroupChannelTypingIndicatorUseCase.swift
+++ b/Apps/TypingIndicatorGroupChannel/Sources/UseCase/GroupChannelTypingIndicatorUseCase.swift
@@ -72,6 +72,6 @@ final class GroupChannelTypingIndicatorUseCase: GroupChannelDelegate {
     }
     
     private func getUsername(user: User) -> String {
-        return user.nickname ?? user.userID
+        return user.nickname ?? user.userId
     }
 }

--- a/Apps/UpdateDeleteMessageGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/UpdateDeleteMessageGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/UpdateDeleteMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/UpdateDeleteMessageGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -204,7 +204,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/UpdateDeleteMessageGroupChannel/Sources/UseCase/UpdateDeleteMessageUseCase.swift
+++ b/Apps/UpdateDeleteMessageGroupChannel/Sources/UseCase/UpdateDeleteMessageUseCase.swift
@@ -20,7 +20,7 @@ final class UpdateDeleteMessageUseCase {
     func updateMessage(_ message: UserMessage, to newMessage: String, completion: @escaping (Result<UserMessage, SBError>) -> Void) {
         let params = UserMessageUpdateParams(message: newMessage)
         
-        channel.updateUserMessage(messageID: message.messageID, params: params) { message, error in
+        channel.updateUserMessage(messageId: message.messageId, params: params) { message, error in
             if let error = error {
                 completion(.failure(error))
                 return
@@ -44,8 +44,8 @@ final class UpdateDeleteMessageUseCase {
     }
     
     func canEdit(message: BaseMessage) -> Bool {
-        let currentUserId = SendbirdChat.getCurrentUser()?.userID
-        return message.sender?.userID == currentUserId
+        let currentUserId = SendbirdChat.getCurrentUser()?.userId
+        return message.sender?.userId == currentUserId
                 || channel.myRole == .operator
     }
     

--- a/Apps/UpdateMessageOpenChannel/Sources/AppDelegate.swift
+++ b/Apps/UpdateMessageOpenChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/UpdateMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
+++ b/Apps/UpdateMessageOpenChannel/Sources/Channel/OpenChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension OpenChannelViewController {
     
     func presentEditMessageAlert(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/UpdateMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/UpdateMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -208,7 +208,7 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
         defer { self.targetMessageForScrolling = nil }
         
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
         

--- a/Apps/UpdateMessageOpenChannel/Sources/UpdateMessageUseCase.swift
+++ b/Apps/UpdateMessageOpenChannel/Sources/UpdateMessageUseCase.swift
@@ -20,7 +20,7 @@ final class UpdateMessageUseCase {
     func updateMessage(_ message: UserMessage, to newMessage: String, completion: @escaping (Result<UserMessage, SBError>) -> Void) {
         let params = UserMessageUpdateParams(message: newMessage)
         
-        channel.updateUserMessage(messageID: message.messageID, params: params) { message, error in
+        channel.updateUserMessage(messageId: message.messageId, params: params) { message, error in
             if let error = error {
                 completion(.failure(error))
                 return

--- a/Apps/UserDoNotDisturbSnooze/Sources/AppDelegate.swift
+++ b/Apps/UserDoNotDisturbSnooze/Sources/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.backgroundColor = .systemBackground

--- a/Apps/UserDoNotDisturbSnooze/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/UserDoNotDisturbSnooze/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/UserDoNotDisturbSnooze/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/UserDoNotDisturbSnooze/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/UserNickNameAndPicture/Sources/AppDelegate.swift
+++ b/Apps/UserNickNameAndPicture/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/UserNickNameAndPicture/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/UserNickNameAndPicture/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/UserNickNameAndPicture/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/UserNickNameAndPicture/Sources/Channel/GroupChannelViewController.swift
@@ -202,7 +202,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/UserNickNameAndPicture/Sources/UserLoginViewController.swift
+++ b/Apps/UserNickNameAndPicture/Sources/UserLoginViewController.swift
@@ -114,7 +114,7 @@ public final class UserLoginViewController: UIViewController {
             
             switch result {
             case .success(let user):
-                if user.nickname?.isEmpty ?? true {
+                if user.nickname.isEmpty {
                     self?.presentEditViewController(user: user)
                 } else {
                     self?.didConnectUser(user)

--- a/Apps/UserNickNameAndPicture/Sources/UserLoginViewController.swift
+++ b/Apps/UserNickNameAndPicture/Sources/UserLoginViewController.swift
@@ -15,22 +15,22 @@ public final class UserLoginViewController: UIViewController {
     
     private let didConnectUser: DidConnectUserHandler
     
-    private lazy var userIDLabel: UILabel = {
-        let userIDLabel: UILabel = UILabel()
-        userIDLabel.text = "USER ID"
-        userIDLabel.font = .boldSystemFont(ofSize: 13)
-        userIDLabel.textColor = .secondaryLabel
-        return userIDLabel
+    private lazy var userIdLabel: UILabel = {
+        let userIdLabel: UILabel = UILabel()
+        userIdLabel.text = "USER ID"
+        userIdLabel.font = .boldSystemFont(ofSize: 13)
+        userIdLabel.textColor = .secondaryLabel
+        return userIdLabel
     }()
     
-    private lazy var userIDTextField: UITextField = {
-        let userIDTextField = UITextField()
-        userIDTextField.placeholder = "USER ID"
-        userIDTextField.font = .systemFont(ofSize: 24)
-        userIDTextField.textColor = .label
-        userIDTextField.tintColor = .systemPurple
-        userIDTextField.borderStyle = .roundedRect
-        return userIDTextField
+    private lazy var userIdTextField: UITextField = {
+        let userIdTextField = UITextField()
+        userIdTextField.placeholder = "USER ID"
+        userIdTextField.font = .systemFont(ofSize: 24)
+        userIdTextField.textColor = .label
+        userIdTextField.tintColor = .systemPurple
+        userIdTextField.borderStyle = .roundedRect
+        return userIdTextField
     }()
     
     private lazy var connectButton: UIButton = {
@@ -60,26 +60,26 @@ public final class UserLoginViewController: UIViewController {
     }
     
     private func setupSubviews() {
-        view.addSubview(userIDLabel)
-        userIDLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(userIdLabel)
+        userIdLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            userIDLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30),
-            userIDLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            userIDLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
+            userIdLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30),
+            userIdLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            userIdLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
         ])
         
-        view.addSubview(userIDTextField)
-        userIDTextField.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(userIdTextField)
+        userIdTextField.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            userIDTextField.topAnchor.constraint(equalTo: userIDLabel.bottomAnchor, constant: 5),
-            userIDTextField.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            userIDTextField.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
+            userIdTextField.topAnchor.constraint(equalTo: userIdLabel.bottomAnchor, constant: 5),
+            userIdTextField.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            userIdTextField.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
         ])
         
         view.addSubview(connectButton)
         connectButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            connectButton.topAnchor.constraint(equalTo: userIDTextField.bottomAnchor, constant: 30),
+            connectButton.topAnchor.constraint(equalTo: userIdTextField.bottomAnchor, constant: 30),
             connectButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
             connectButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             connectButton.heightAnchor.constraint(equalToConstant: 50)
@@ -87,8 +87,8 @@ public final class UserLoginViewController: UIViewController {
     }
     
     private func loadCachedUser() {
-        if let userID = UserConnectionUseCase.shared.userID {
-            userIDTextField.text = userID
+        if let userId = UserConnectionUseCase.shared.userId {
+            userIdTextField.text = userId
         }
         
         if UserConnectionUseCase.shared.isAutoLogin {
@@ -100,8 +100,8 @@ public final class UserLoginViewController: UIViewController {
         view.endEditing(true)
         
         guard
-            let userID = userIDTextField.text,
-            validateText(userID: userID)
+            let userId = userIdTextField.text,
+            validateText(userId: userId)
         else {
             presentAlert(title: "Error", message: "User ID and Nickname are required.")
             return
@@ -109,7 +109,7 @@ public final class UserLoginViewController: UIViewController {
         
         updateUIForConnecting()
         
-        UserConnectionUseCase.shared.login(userID: userID) { [weak self] result in
+        UserConnectionUseCase.shared.login(userId: userId) { [weak self] result in
             self?.updateUIForDefault()
             
             switch result {
@@ -135,18 +135,18 @@ public final class UserLoginViewController: UIViewController {
         present(navigation, animated: true)
     }
     
-    private func validateText(userID: String) -> Bool {
-        userID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+    private func validateText(userId: String) -> Bool {
+        userId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }
     
     private func updateUIForDefault() {
-        userIDTextField.isEnabled = true
+        userIdTextField.isEnabled = true
         connectButton.isEnabled = true
         connectButton.setTitle("Connect", for: .normal)
     }
 
     private func updateUIForConnecting() {
-        userIDTextField.isEnabled = false
+        userIdTextField.isEnabled = false
         connectButton.isEnabled = false
         connectButton.setTitle("Connecting...", for: .normal)
     }
@@ -163,7 +163,7 @@ public final class UserLoginViewController: UIViewController {
 extension UserLoginViewController: UITextFieldDelegate {
     
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if textField == userIDTextField {
+        if textField == userIdTextField {
             connectUser()
             textField.resignFirstResponder()
         }

--- a/Apps/iOSTrueGroupChannel/Sources/AppDelegate.swift
+++ b/Apps/iOSTrueGroupChannel/Sources/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        EnvironmentUseCase.initializeSendbirdSDK(applicationID: .sample)
+        EnvironmentUseCase.initializeSendbirdSDK(applicationId: .sample)
         BaseAppearance.apply()
         
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Apps/iOSTrueGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
+++ b/Apps/iOSTrueGroupChannel/Sources/Channel/GroupChannelViewController+EditMessage.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 extension GroupChannelViewController {
     
     func handleLongPress(for message: BaseMessage) {
-        guard message.sender?.userID == SendbirdChat.getCurrentUser()?.userID else { return }
+        guard message.sender?.userId == SendbirdChat.getCurrentUser()?.userId else { return }
         
         if let userMessage = message as? UserMessage {
             presentEditUserMessageAlert(for: userMessage)

--- a/Apps/iOSTrueGroupChannel/Sources/Channel/GroupChannelViewController.swift
+++ b/Apps/iOSTrueGroupChannel/Sources/Channel/GroupChannelViewController.swift
@@ -208,7 +208,7 @@ extension GroupChannelViewController: GroupChannelMessageListUseCaseDelegate {
     
     private func scrollToFocusMessage() {
         guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageID == messageListUseCase.messages.last?.messageID else { return }
+              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
         self.targetMessageForScrolling = nil
         
         let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)

--- a/Apps/iOSTrueGroupChannel/Sources/UseCase/iOSTrueUseCase.swift
+++ b/Apps/iOSTrueGroupChannel/Sources/UseCase/iOSTrueUseCase.swift
@@ -45,8 +45,9 @@ class iOSTrueUseCase: NSObject {
         
     private func createApplicationUserListQuery() -> ApplicationUserListQuery {
         let currentUserId = SendbirdChat.getCurrentUser()!.userId
-        let query = SendbirdChat.createApplicationUserListQuery()
-        query.userIdsFilter = [currentUserId]
+        let query = SendbirdChat.createApplicationUserListQuery {
+            $0.userIdsFilter = [currentUserId]
+        }
         return query
     }
 }

--- a/Apps/iOSTrueGroupChannel/Sources/UseCase/iOSTrueUseCase.swift
+++ b/Apps/iOSTrueGroupChannel/Sources/UseCase/iOSTrueUseCase.swift
@@ -44,25 +44,25 @@ class iOSTrueUseCase: NSObject {
     }
         
     private func createApplicationUserListQuery() -> ApplicationUserListQuery {
-        let currentUserId = SendbirdChat.getCurrentUser()!.userID
+        let currentUserId = SendbirdChat.getCurrentUser()!.userId
         let query = SendbirdChat.createApplicationUserListQuery()
-        query.userIDsFilter = [currentUserId]
+        query.userIdsFilter = [currentUserId]
         return query
     }
 }
 
 extension iOSTrueUseCase: ConnectionDelegate {
     
-    func didConnect(userID: String) {
-        let currentUserId = SendbirdChat.getCurrentUser()!.userID
-        if userID == currentUserId {
+    func didConnect(userId: String) {
+        let currentUserId = SendbirdChat.getCurrentUser()!.userId
+        if userId == currentUserId {
             self.delegate?.userConnection(self, didUpdateUserStatus: true)
         }
     }
     
-    func didDisconnect(userID: String) {
-        let currentUserId = SendbirdChat.getCurrentUser()!.userID
-        if userID == currentUserId {
+    func didDisconnect(userId: String) {
+        let currentUserId = SendbirdChat.getCurrentUser()!.userId
+        if userId == currentUserId {
             self.delegate?.userConnection(self, didUpdateUserStatus: false)
         }
     }

--- a/Modules/CommonModule/Sources/UseCase/EnvironmentUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/EnvironmentUseCase.swift
@@ -24,9 +24,9 @@ public class EnvironmentUseCase {
         }
     }
     
-    public static func initializeSendbirdSDK(applicationID: ApplicationId) {
+    public static func initializeSendbirdSDK(applicationId: ApplicationId) {
         let initParams = InitParams(
-            applicationID: applicationID.rawValue,
+            applicationId: applicationId.rawValue,
             isLocalCachingEnabled: false,
             logLevel: .error,
             appVersion: "1.0.0"

--- a/Modules/CommonModule/Sources/UseCase/GroupChannel/GroupChannelFileMessageUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/GroupChannel/GroupChannelFileMessageUseCase.swift
@@ -46,20 +46,20 @@ open class GroupChannelFileMessageUseCase {
             
             guard let message = message else { return }
             
-            self?.cachedDatasForResending.removeValue(forKey: message.requestID)
+            self?.cachedDatasForResending.removeValue(forKey: message.requestId)
             
             completion(.success(message))
         }
         
-        if let requestID = fileMessage?.requestID {
-            cachedDatasForResending[requestID] = mediaFile.data
+        if let requestId = fileMessage?.requestId {
+            cachedDatasForResending[requestId] = mediaFile.data
         }
         
         return fileMessage
     }
     
     open func resendMessage(_ message: FileMessage, completion: @escaping (Result<BaseMessage, SBError>) -> Void) {
-        guard let binaryData = cachedDatasForResending[message.requestID] else { return }
+        guard let binaryData = cachedDatasForResending[message.requestId] else { return }
         
         channel.resendFileMessage(message, binaryData: binaryData) { message, error in
             if let error = error {

--- a/Modules/CommonModule/Sources/UseCase/GroupChannel/GroupChannelMessageListUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/GroupChannel/GroupChannelMessageListUseCase.swift
@@ -154,8 +154,8 @@ open class GroupChannelMessageListUseCase: NSObject {
     private func replaceMessages(_ newMessages: [BaseMessage]) {
         newMessages.forEach { newMessage in
             if let index = messages.firstIndex(where: {
-                $0.messageID == newMessage.messageID
-                || $0.requestID == newMessage.requestID
+                $0.messageId == newMessage.messageId
+                || $0.requestId == newMessage.requestId
             }) {
                 messages[index] = newMessage
             }
@@ -188,7 +188,7 @@ extension GroupChannelMessageListUseCase: MessageCollectionDelegate {
         switch context.sendingStatus {
         case .succeeded:
             self.messages = self.messages.filter { oldMessage in
-                deletedMessages.map { $0.messageID }.contains(oldMessage.messageID) == false
+                deletedMessages.map { $0.messageId }.contains(oldMessage.messageId) == false
             }
         case .failed:
             // Remove the failed message from your data source.

--- a/Modules/CommonModule/Sources/UseCase/GroupChannel/GroupChannelUserMessageUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/GroupChannel/GroupChannelUserMessageUseCase.swift
@@ -45,7 +45,7 @@ open class GroupChannelUserMessageUseCase {
     open func updateMessage(_ message: UserMessage, to newMessage: String, completion: @escaping (Result<UserMessage, SBError>) -> Void) {
         let params = UserMessageUpdateParams(message: newMessage)
         
-        channel.updateUserMessage(messageID: message.messageID, params: params) { message, error in
+        channel.updateUserMessage(messageId: message.messageId, params: params) { message, error in
             if let error = error {
                 completion(.failure(error))
                 return

--- a/Modules/CommonModule/Sources/UseCase/GroupChannel/GroupChannelUserSelectionUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/GroupChannel/GroupChannelUserSelectionUseCase.swift
@@ -71,8 +71,9 @@ open class GroupChannelUserSelectionUseCase {
     }
     
     open func createApplicationUserListQuery() -> ApplicationUserListQuery {
-        let query = SendbirdChat.createApplicationUserListQuery()
-        query.limit = 20
+        let query = SendbirdChat.createApplicationUserListQuery {
+            $0.limit = 20
+        }
         return query
     }
     
@@ -94,17 +95,17 @@ open class GroupChannelUserSelectionUseCase {
         let currentUser = SendbirdChat.getCurrentUser()
 
         return users.filter {
-            $0.userID != currentUser?.userID
-            && hasMember(ofUserId: $0.userID) == false
+            $0.userId != currentUser?.userId
+            && hasMember(ofUserId: $0.userId) == false
         }
     }
     
-    private func hasMember(ofUserId userID: String) -> Bool {
+    private func hasMember(ofUserId userId: String) -> Bool {
         guard let channel = channel else {
             return false
         }
 
-        return channel.hasMember(userID)
+        return channel.hasMember(userId)
     }
     
 }

--- a/Modules/CommonModule/Sources/UseCase/GroupChannelList/CreateGroupChannelUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/GroupChannelList/CreateGroupChannelUseCase.swift
@@ -23,8 +23,8 @@ open class CreateGroupChannelUseCase {
         params.addUsers(users)
         params.name = channelName
         
-        if let operatorUserId = SendbirdChat.getCurrentUser()?.userID {
-            params.operatorUserIDs = [operatorUserId]
+        if let operatorUserId = SendbirdChat.getCurrentUser()?.userId {
+            params.operatorUserIds = [operatorUserId]
         }
         
         GroupChannel.createChannel(params: params) { channel, error in

--- a/Modules/CommonModule/Sources/UseCase/GroupChannelList/GroupChannelListUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/GroupChannelList/GroupChannelListUseCase.swift
@@ -63,10 +63,11 @@ open class GroupChannelListUseCase: NSObject {
     }
         
     open func createGroupChannelListCollection() -> GroupChannelCollection? {
-        let channelListQuery = GroupChannel.createMyGroupChannelListQuery()
-        channelListQuery.order = .latestLastMessage
-        channelListQuery.limit = 20
-        channelListQuery.includeEmptyChannel = true
+        let channelListQuery = GroupChannel.createMyGroupChannelListQuery {
+            $0.order = .latestLastMessage
+            $0.limit = 20
+            $0.includeEmptyChannel = true
+        }
         
         let collection = SendbirdChat.createGroupChannelCollection(query: channelListQuery)
         collection?.delegate = self

--- a/Modules/CommonModule/Sources/UseCase/OpenChannel/OpenChannelFileMessageUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/OpenChannel/OpenChannelFileMessageUseCase.swift
@@ -46,20 +46,20 @@ open class OpenChannelFileMessageUseCase {
             
             guard let message = message else { return }
             
-            self?.cachedDatasForResending.removeValue(forKey: message.requestID)
+            self?.cachedDatasForResending.removeValue(forKey: message.requestId)
             
             completion(.success(message))
         }
         
-        if let requestID = fileMessage?.requestID {
-            cachedDatasForResending[requestID] = mediaFile.data
+        if let requestId = fileMessage?.requestId {
+            cachedDatasForResending[requestId] = mediaFile.data
         }
             
         return fileMessage
     }
     
     open func resendMessage(_ message: FileMessage, completion: @escaping (Result<BaseMessage, SBError>) -> Void) {
-        guard let binaryData = cachedDatasForResending[message.requestID] else { return }
+        guard let binaryData = cachedDatasForResending[message.requestId] else { return }
         
         channel.resendFileMessage(message, binaryData: binaryData) { message, error in
             if let error = error {

--- a/Modules/CommonModule/Sources/UseCase/OpenChannel/OpenChannelMessageListUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/OpenChannel/OpenChannelMessageListUseCase.swift
@@ -198,14 +198,14 @@ extension OpenChannelMessageListUseCase: BaseChannelDelegate, OpenChannelDelegat
         replaceMessages([message])
     }
     
-    open func channel(_ sender: BaseChannel, messageWasDeleted messageID: Int64) {
+    open func channel(_ sender: BaseChannel, messageWasDeleted messageId: Int64) {
         guard sender.channelURL == channel.channelURL else { return }
         
-        deleteMessages(byMessageIds: [messageID])
+        deleteMessages(byMessageIds: [messageId])
     }
     
     private func appendNewMessage(_ message: BaseMessage) {
-        guard messages.contains(where: { $0.messageID == message.messageID }) == false else { return }
+        guard messages.contains(where: { $0.messageId == message.messageId }) == false else { return }
         
         self.messages.append(message)
     }
@@ -213,24 +213,24 @@ extension OpenChannelMessageListUseCase: BaseChannelDelegate, OpenChannelDelegat
     private func replaceMessages(_ newMessages: [BaseMessage]) {
         newMessages.forEach { newMessage in
             if let index = messages.firstIndex(where: {
-                $0.messageID == newMessage.messageID
-                || $0.requestID == newMessage.requestID
+                $0.messageId == newMessage.messageId
+                || $0.requestId == newMessage.requestId
             }) {
                 messages[index] = newMessage
             }
         }
     }
     
-    private func deleteMessages(byMessageIds messageIDs: [Int64]) {
+    private func deleteMessages(byMessageIds messageIds: [Int64]) {
         self.messages = self.messages.filter {
-            messageIDs.contains($0.messageID) == false
+            messageIds.contains($0.messageId) == false
         }
     }
         
     private func deleteMessage(_ message: BaseMessage) {
         self.messages = self.messages.filter {
-            $0.requestID != message.requestID
-            && $0.messageID != message.messageID
+            $0.requestId != message.requestId
+            && $0.messageId != message.messageId
         }
     }
     

--- a/Modules/CommonModule/Sources/UseCase/OpenChannel/OpenChannelUserMessageUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/OpenChannel/OpenChannelUserMessageUseCase.swift
@@ -45,7 +45,7 @@ open class OpenChannelUserMessageUseCase {
     open func updateMessage(_ message: UserMessage, to newMessage: String, completion: @escaping (Result<UserMessage, SBError>) -> Void) {
         let params = UserMessageUpdateParams(message: newMessage)
 
-        channel.updateUserMessage(messageID: message.messageID, params: params) { message, error in
+        channel.updateUserMessage(messageId: message.messageId, params: params) { message, error in
             if let error = error {
                 completion(.failure(error))
                 return

--- a/Modules/CommonModule/Sources/UseCase/OpenChannelList/CreateOpenChannelUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/OpenChannelList/CreateOpenChannelUseCase.swift
@@ -14,7 +14,7 @@ open class CreateOpenChannelUseCase {
     
     open func createOpenChannel(channelName: String?, imageData: Data?, completion: @escaping (Result<OpenChannel, SBError>) -> Void) {
         let params = OpenChannelCreateParams()
-        params.operatorUserIDs = [SendbirdChat.getCurrentUser()?.userID].compactMap { $0 }
+        params.operatorUserIds = [SendbirdChat.getCurrentUser()?.userId].compactMap { $0 }
         params.coverImage = imageData
         params.name = channelName
 

--- a/Modules/CommonModule/Sources/UseCase/OpenChannelList/OpenChannelListUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/OpenChannelList/OpenChannelListUseCase.swift
@@ -65,8 +65,9 @@ open class OpenChannelListUseCase: NSObject {
     }
         
     open func createOpenChannelListQuery() -> OpenChannelListQuery {
-        let channelListQuery = OpenChannel.createOpenChannelListQuery()
-        channelListQuery.limit = 20
+        let channelListQuery = OpenChannel.createOpenChannelListQuery {
+            $0.limit = 20
+        }
         return channelListQuery
     }
     

--- a/Modules/CommonModule/Sources/UseCase/User/UserConnectionUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/User/UserConnectionUseCase.swift
@@ -16,7 +16,7 @@ public class UserConnectionUseCase {
     public private(set) var isAutoLogin: Bool
     
     @UserDefault(key: "sendbird_user_id", defaultValue: nil)
-    public private(set) var userID: String?
+    public private(set) var userId: String?
     
     public var currentUser: User? {
         SendbirdChat.getCurrentUser()
@@ -24,9 +24,9 @@ public class UserConnectionUseCase {
         
     private init() { }
     
-    public func login(userID: String,
+    public func login(userId: String,
                       completion: @escaping (Result<User, SBError>) -> Void) {
-        SendbirdChat.connect(userID: userID) { [weak self] user, error in
+        SendbirdChat.connect(userId: userId) { [weak self] user, error in
             if let error = error {
                 completion(.failure(error))
                 return
@@ -83,7 +83,7 @@ public class UserConnectionUseCase {
     }
         
     private func storeUserInfo(_ user: User) {
-        userID = user.userID
+        userId = user.userId
         isAutoLogin = true
     }
             

--- a/Modules/CommonModule/Sources/View/GroupChannel/User/BasicChannelMemberCell.swift
+++ b/Modules/CommonModule/Sources/View/GroupChannel/User/BasicChannelMemberCell.swift
@@ -69,7 +69,7 @@ open class BasicChannelMemberCell: UITableViewCell {
     }
 
     public func configure(with user: User) {
-        profileLabel.text = "\(user.nickname ?? "(Unknown)") \(connectionStatus(with: user))"
+        profileLabel.text = "\(user.nickname) \(connectionStatus(with: user))"
         profileImageView.setProfileImageView(for: user)
     }
     

--- a/Modules/CommonModule/Sources/View/Message/BasicFileCell.swift
+++ b/Modules/CommonModule/Sources/View/Message/BasicFileCell.swift
@@ -123,7 +123,7 @@ public class BasicFileCell: UITableViewCell {
 
     public func configure(with message: FileMessage) {
         if let sender = message.sender {
-            profileLabel.text = "\(sender.nickname ?? "(Unknown)")"
+            profileLabel.text = "\(sender.nickname)"
             profileImageView.setProfileImageView(for: sender)
         }
         

--- a/Modules/CommonModule/Sources/View/Message/BasicMessageCell.swift
+++ b/Modules/CommonModule/Sources/View/Message/BasicMessageCell.swift
@@ -90,7 +90,7 @@ open class BasicMessageCell: UITableViewCell {
 
     public func configure(with message: BaseMessage) {
         if let sender = message.sender {
-            profileLabel.text = "\(sender.nickname ?? "(Unknown)")"
+            profileLabel.text = "\(sender.nickname)"
             profileImageView.setProfileImageView(for: sender)
         } else if message is AdminMessage {
             profileLabel.text = "Admin"

--- a/Modules/CommonModule/Sources/View/User/Login/LoginViewController.swift
+++ b/Modules/CommonModule/Sources/View/User/Login/LoginViewController.swift
@@ -14,22 +14,22 @@ public final class LoginViewController: UIViewController {
     
     private let didConnectUser: DidConnectUserHandler
     
-    private lazy var userIDLabel: UILabel = {
-        let userIDLabel: UILabel = UILabel()
-        userIDLabel.text = "USER ID"
-        userIDLabel.font = .boldSystemFont(ofSize: 13)
-        userIDLabel.textColor = .secondaryLabel
-        return userIDLabel
+    private lazy var userIdLabel: UILabel = {
+        let userIdLabel: UILabel = UILabel()
+        userIdLabel.text = "USER ID"
+        userIdLabel.font = .boldSystemFont(ofSize: 13)
+        userIdLabel.textColor = .secondaryLabel
+        return userIdLabel
     }()
     
-    private lazy var userIDTextField: UITextField = {
-        let userIDTextField = UITextField()
-        userIDTextField.placeholder = "USER ID"
-        userIDTextField.font = .systemFont(ofSize: 24)
-        userIDTextField.textColor = .label
-        userIDTextField.tintColor = .systemPurple
-        userIDTextField.borderStyle = .roundedRect
-        return userIDTextField
+    private lazy var userIdTextField: UITextField = {
+        let userIdTextField = UITextField()
+        userIdTextField.placeholder = "USER ID"
+        userIdTextField.font = .systemFont(ofSize: 24)
+        userIdTextField.textColor = .label
+        userIdTextField.tintColor = .systemPurple
+        userIdTextField.borderStyle = .roundedRect
+        return userIdTextField
     }()
     
     private lazy var connectButton: UIButton = {
@@ -59,26 +59,26 @@ public final class LoginViewController: UIViewController {
     }
     
     private func setupSubviews() {
-        view.addSubview(userIDLabel)
-        userIDLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(userIdLabel)
+        userIdLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            userIDLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30),
-            userIDLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            userIDLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
+            userIdLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 30),
+            userIdLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            userIdLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
         ])
         
-        view.addSubview(userIDTextField)
-        userIDTextField.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(userIdTextField)
+        userIdTextField.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            userIDTextField.topAnchor.constraint(equalTo: userIDLabel.bottomAnchor, constant: 5),
-            userIDTextField.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
-            userIDTextField.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
+            userIdTextField.topAnchor.constraint(equalTo: userIdLabel.bottomAnchor, constant: 5),
+            userIdTextField.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            userIdTextField.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20)
         ])
         
         view.addSubview(connectButton)
         connectButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            connectButton.topAnchor.constraint(equalTo: userIDTextField.bottomAnchor, constant: 30),
+            connectButton.topAnchor.constraint(equalTo: userIdTextField.bottomAnchor, constant: 30),
             connectButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
             connectButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             connectButton.heightAnchor.constraint(equalToConstant: 50)
@@ -86,8 +86,8 @@ public final class LoginViewController: UIViewController {
     }
     
     private func loadCachedUser() {
-        if let userID = UserConnectionUseCase.shared.userID {
-            userIDTextField.text = userID
+        if let userId = UserConnectionUseCase.shared.userId {
+            userIdTextField.text = userId
         }
         
         if UserConnectionUseCase.shared.isAutoLogin {
@@ -99,8 +99,8 @@ public final class LoginViewController: UIViewController {
         view.endEditing(true)
         
         guard
-            let userID = userIDTextField.text,
-            validateText(userID: userID)
+            let userId = userIdTextField.text,
+            validateText(userId: userId)
         else {
             presentAlert(title: "Error", message: "User ID and Nickname are required.")
             return
@@ -108,12 +108,12 @@ public final class LoginViewController: UIViewController {
         
         updateUIForConnecting()
         
-        UserConnectionUseCase.shared.login(userID: userID) { [weak self] result in
+        UserConnectionUseCase.shared.login(userId: userId) { [weak self] result in
             self?.updateUIForDefault()
             
             switch result {
             case .success(let user):
-                if user.nickname?.isEmpty ?? true {
+                if user.nickname.isEmpty {
                     self?.presentEditViewController(user: user)
                 } else {
                     self?.didConnectUser(user)
@@ -134,18 +134,18 @@ public final class LoginViewController: UIViewController {
         present(navigation, animated: true)
     }
     
-    private func validateText(userID: String) -> Bool {
-        userID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+    private func validateText(userId: String) -> Bool {
+        userId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }
     
     private func updateUIForDefault() {
-        userIDTextField.isEnabled = true
+        userIdTextField.isEnabled = true
         connectButton.isEnabled = true
         connectButton.setTitle("Connect", for: .normal)
     }
 
     private func updateUIForConnecting() {
-        userIDTextField.isEnabled = false
+        userIdTextField.isEnabled = false
         connectButton.isEnabled = false
         connectButton.setTitle("Connecting...", for: .normal)
     }
@@ -162,7 +162,7 @@ public final class LoginViewController: UIViewController {
 extension LoginViewController: UITextFieldDelegate {
     
     public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if textField == userIDTextField {
+        if textField == userIdTextField {
             connectUser()
             textField.resignFirstResponder()
         }

--- a/Modules/CommonModule/Sources/View/User/Profile/ProfileImageView.swift
+++ b/Modules/CommonModule/Sources/View/User/Profile/ProfileImageView.swift
@@ -193,7 +193,7 @@ extension UIImageView {
     }
     
     private func defaultUserProfileImage(user: User) -> UIImage? {
-        if let nickname = user.nickname, let image = UIImage.named("img_default_profile_image_\(nickname.count % 4)") {
+        if let image = UIImage.named("img_default_profile_image_\(user.nickname.count % 4)") {
             return image
         }
         

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -9,8 +9,8 @@ import ProjectDescription
 
 let dependencies = Dependencies(
     swiftPackageManager: [
-        .remote(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", requirement: .upToNextMinor(from: "4.0.0-beta.3")),
-        .remote(url: "https://github.com/onevcat/Kingfisher", requirement: .upToNextMajor(from: "7.2.0")),
+        .remote(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", requirement: .exact("4.0.0")),
+        .remote(url: "https://github.com/onevcat/Kingfisher", requirement: .exact("7.2.0")),
     ],
     platforms: [.iOS]
 )


### PR DESCRIPTION
## Dependencies.swift

I changed Dependencies to use exact version
```swift
.remote(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", requirement: .exact("4.0.0")),
.remote(url: "https://github.com/onevcat/Kingfisher", requirement: .exact("7.2.0")),
```

## Migrations

* ID -> Id
* Now we can create query object with builder closure. for example; 
```swift
let channelListQuery = GroupChannel.createMyGroupChannelListQuery {
    $0.order = .latestLastMessage
    $0.limit = 20
    $0.includeEmptyChannel = true
}
```