### PR TITLE
Update for Xcode 14.1+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .AppleDouble
 .LSOverride
 
+# AppCode
+.idea
+
 # Icon must end with two
 Icon
 

--- a/Apps/DeleteMessageOpenChannel/Sources/UseCase/DeleteMessageUseCase.swift
+++ b/Apps/DeleteMessageOpenChannel/Sources/UseCase/DeleteMessageUseCase.swift
@@ -19,7 +19,7 @@ final class DeleteMessageUseCase {
     }
     
     private func subscribeToDeleteMessageDelegate() {
-        SendbirdChat.add(self, identifier: "[DELETE_MESSAGE_DELEGATE]")
+        SendbirdChat.addChannelDelegate(self, identifier: "[DELETE_MESSAGE_DELEGATE]")
     }
 
     func deleteMessage(_ message: BaseMessage, completion: @escaping (Result<Void, SBError>) -> Void) {

--- a/Apps/MarkAsReadGroupChannel/Sources/UseCase/MarkAsReadUseCase.swift
+++ b/Apps/MarkAsReadGroupChannel/Sources/UseCase/MarkAsReadUseCase.swift
@@ -32,7 +32,7 @@ class MarkAsReadUseCase: GroupChannelDelegate {
     }
     
     private func subscribeToGroupChannelDelegate() {
-        SendbirdChat.add(self, identifier: String(describing: self))
+        SendbirdChat.addChannelDelegate(self, identifier: String(describing: self))
     }
 
     func markAsRead() {

--- a/Apps/MentionUsersInMessageGroupChannel/Sources/Channel/MentionedUserMessageCell.swift
+++ b/Apps/MentionUsersInMessageGroupChannel/Sources/Channel/MentionedUserMessageCell.swift
@@ -40,7 +40,7 @@ class MentionedUserMessageCell: BasicMessageCell {
     ) {
         configure(with: message)
         let userNames: [String] = message.mentionedUsers.map {
-            $0.nickname ?? $0.userId
+            $0.nickname
         }
         usersLabel.text = userNames.joined(separator: ",")
     }

--- a/Apps/MentionUsersInMessageOpenChannel/Sources/Channel/MentionedUserMessageCell.swift
+++ b/Apps/MentionUsersInMessageOpenChannel/Sources/Channel/MentionedUserMessageCell.swift
@@ -40,7 +40,7 @@ class MentionedUserMessageCell: BasicMessageCell {
     ) {
         configure(with: message)
         let userNames: [String] = message.mentionedUsers.map {
-            $0.nickname ?? $0.userId
+            $0.nickname
         }
         usersLabel.text = userNames.joined(separator: ",")
     }

--- a/Apps/PollsGroupChannel/Sources/Poll/TimePicker.swift
+++ b/Apps/PollsGroupChannel/Sources/Poll/TimePicker.swift
@@ -22,7 +22,7 @@ extension UIAlertController{
         addAction(UIAlertAction(title: "Done", style: .cancel, handler: { action in
             onDateSelected(datePicker.date)
         }))
-        let height: NSLayoutConstraint = NSLayoutConstraint(item: view, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.1, constant: 300)
+        let height: NSLayoutConstraint = NSLayoutConstraint(item: view!, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.1, constant: 300)
         view.addConstraint(height)
 
         datePicker.translatesAutoresizingMaskIntoConstraints = false

--- a/Apps/PushNotificationsGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
+++ b/Apps/PushNotificationsGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
@@ -42,7 +42,7 @@ class PushNotificationUseCase {
             })
         }
         else {
-            SendbirdChat.unregisterPushToken(pushToken, completionHandler: { (response, error) in
+            SendbirdChat.unregisterPushToken(pushToken, completionHandler: { error in
                 guard error == nil else {
                     // Handle error.
                     return
@@ -52,13 +52,12 @@ class PushNotificationUseCase {
     }
     
     func unRegisterAllDevices() {
-        SendbirdChat.unregisterAllPushToken(completionHandler: { (response, error) in
+        SendbirdChat.unregisterAllPushToken(completionHandler: { error in
             guard error == nil else {
                 // Handle error.
                 return
             }
         })
-
     }
 
 }

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
@@ -42,7 +42,7 @@ class PushNotificationUseCase {
             })
         }
         else {
-            SendbirdChat.unregisterPushToken(pushToken, completionHandler: { (response, error) in
+            SendbirdChat.unregisterPushToken(pushToken, completionHandler: { error in
                 guard error == nil else {
                     // Handle error.
                     return
@@ -52,7 +52,7 @@ class PushNotificationUseCase {
     }
     
     func unRegisterAllDevices() {
-        SendbirdChat.unregisterAllPushToken(completionHandler: { (response, error) in
+        SendbirdChat.unregisterAllPushToken(completionHandler: { error in
             guard error == nil else {
                 // Handle error.
                 return

--- a/Apps/ScheduledMessagesGroupChannel/Sources/Channel/UIDateTimePickerAlertController.swift
+++ b/Apps/ScheduledMessagesGroupChannel/Sources/Channel/UIDateTimePickerAlertController.swift
@@ -23,7 +23,7 @@ extension UIAlertController{
         addAction(UIAlertAction(title: "Done", style: .cancel, handler: { action in
             onDateSelected(datePicker.date)
         }))
-        let height: NSLayoutConstraint = NSLayoutConstraint(item: view, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.1, constant: 300)
+        let height: NSLayoutConstraint = NSLayoutConstraint(item: view!, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1.1, constant: 300)
         view.addConstraint(height)
         
         datePicker.translatesAutoresizingMaskIntoConstraints = false

--- a/Apps/TypingIndicatorGroupChannel/Sources/UseCase/GroupChannelTypingIndicatorUseCase.swift
+++ b/Apps/TypingIndicatorGroupChannel/Sources/UseCase/GroupChannelTypingIndicatorUseCase.swift
@@ -28,7 +28,7 @@ final class GroupChannelTypingIndicatorUseCase: GroupChannelDelegate {
     }
     
     private func subscribeToTypingIndicatorDelegate() {
-        SendbirdChat.add(self, identifier: "[TYPING_INDICATOR_DELEGATE]")
+        SendbirdChat.addChannelDelegate(self, identifier: "[TYPING_INDICATOR_DELEGATE]")
     }
     
     func startTyping() {
@@ -72,6 +72,6 @@ final class GroupChannelTypingIndicatorUseCase: GroupChannelDelegate {
     }
     
     private func getUsername(user: User) -> String {
-        return user.nickname ?? user.userId
+        return user.nickname
     }
 }

--- a/Apps/UserDoNotDisturbSnooze/Sources/UseCase/PushNotificationUseCase.swift
+++ b/Apps/UserDoNotDisturbSnooze/Sources/UseCase/PushNotificationUseCase.swift
@@ -42,7 +42,7 @@ class PushNotificationUseCase {
             })
         }
         else {
-            SendbirdChat.unregisterPushToken(pushToken, completionHandler: { (response, error) in
+            SendbirdChat.unregisterPushToken(pushToken, completionHandler: { error in
                 guard error == nil else {
                     // Handle error.
                     return
@@ -52,7 +52,7 @@ class PushNotificationUseCase {
     }
     
     func unRegisterAllDevices() {
-        SendbirdChat.unregisterAllPushToken(completionHandler: { (response, error) in
+        SendbirdChat.unregisterAllPushToken(completionHandler: { error in
             guard error == nil else {
                 // Handle error.
                 return

--- a/Apps/iOSTrueGroupChannel/Sources/UseCase/iOSTrueUseCase.swift
+++ b/Apps/iOSTrueGroupChannel/Sources/UseCase/iOSTrueUseCase.swift
@@ -26,7 +26,7 @@ class iOSTrueUseCase: NSObject {
     init(channel: GroupChannel?) {
         self.channel = channel
         super.init()
-        SendbirdChat.add(self as ConnectionDelegate, identifier: "[CONNECTION_DELEGATE]")
+        SendbirdChat.addConnectionDelegate(self as ConnectionDelegate, identifier: "[CONNECTION_DELEGATE]")
     }
         
     func checkUserConnectionStatus() {

--- a/Modules/CommonModule/Sources/UseCase/EnvironmentUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/EnvironmentUseCase.swift
@@ -27,7 +27,7 @@ public class EnvironmentUseCase {
     public static func initializeSendbirdSDK(applicationId: ApplicationId) {
         let initParams = InitParams(
             applicationId: applicationId.rawValue,
-            isLocalCachingEnabled: false,
+            isLocalCachingEnabled: true,
             logLevel: .error,
             appVersion: "1.0.0"
         )

--- a/Modules/CommonModule/Sources/UseCase/GroupChannel/GroupChannelUserSelectionUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/GroupChannel/GroupChannelUserSelectionUseCase.swift
@@ -35,11 +35,13 @@ open class GroupChannelUserSelectionUseCase {
     open func reloadUsers() {
         userListQuery = createApplicationUserListQuery()
         
-        guard let userListQuery = userListQuery, userListQuery.hasNext else { return }
-        
+        guard let userListQuery = userListQuery,
+              userListQuery.hasNext,
+              userListQuery.isLoading == false else { return }
+
         userListQuery.loadNextPage { [weak self] users, error in
             guard let self = self else { return }
-            
+
             if let error = error {
                 self.delegate?.userSelectionUseCase(self, didReceiveError: error)
                 return
@@ -53,11 +55,13 @@ open class GroupChannelUserSelectionUseCase {
     }
     
     open func loadNextPage() {
-        guard let userListQuery = userListQuery, userListQuery.hasNext else { return }
-        
+        guard let userListQuery = userListQuery,
+              userListQuery.hasNext,
+              userListQuery.isLoading == false else { return }
+
         userListQuery.loadNextPage { [weak self] users, error in
             guard let self = self else { return }
-            
+
             if let error = error {
                 self.delegate?.userSelectionUseCase(self, didReceiveError: error)
                 return

--- a/Modules/CommonModule/Sources/Util/UIColor+Extension.swift
+++ b/Modules/CommonModule/Sources/Util/UIColor+Extension.swift
@@ -14,10 +14,10 @@ public extension UIColor {
             let hexString: String = hexString.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
             let scanner = Scanner(string: hexString)
             if (hexString.hasPrefix("#")) {
-                scanner.scanLocation = 1
+                scanner.currentIndex = hexString.index(after: hexString.startIndex)
             }
-            var color: UInt32 = 0
-            scanner.scanHexInt32(&color)
+            var color: UInt64 = 0
+            scanner.scanHexInt64(&color)
             let mask = 0x000000FF
             let r = Int(color >> 16) & mask
             let g = Int(color >> 8) & mask

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -9,7 +9,7 @@ import ProjectDescription
 
 let dependencies = Dependencies(
     swiftPackageManager: [
-        .remote(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", requirement: .upToNextMinor(from: "4.2.1")),
+        .remote(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", requirement: .upToNextMinor(from: "4.6.3")),
         .remote(url: "https://github.com/onevcat/Kingfisher", requirement: .upToNextMinor(from: "7.2.0")),
     ],
     platforms: [.iOS]


### PR DESCRIPTION
### Background
Apple announced that starting April 25, 2023, iOS, iPadOS, and watchOS apps submitted to the App Store must be built with Xcode 14.1 or later(https://developer.apple.com/news/?id=jd9wcyov ).
It should be verified that all iOS SampleApps in Sendbird run on Xcode14.1+.

### Summary
- [fix errors when loading the following user lists](https://github.com/sendbird/sendbird-chat-sample-ios/commit/69adc88254f88ab341d0026b8888016405d21df3)
- [change the target sdk version to 4.6.3](https://github.com/sendbird/sendbird-chat-sample-ios/commit/dcb2c31998b1127c09e5019decdcf8ad2a4f5c23)
- [Change the use of deprecated](https://github.com/sendbird/sendbird-chat-sample-ios/commit/ada39e0c66bf69a008cf7897295e5a7e8e845a14)
- [Applying Xcode warning hints](https://github.com/sendbird/sendbird-chat-sample-ios/commit/b6b3bfaf57e9aafd7689fc10f183a7d638c6c273)
- [Add .idea to .gitignore](https://github.com/sendbird/sendbird-chat-sample-ios/commit/9ff973de93ee940e04ed30c33c602420014647f9)


### Further Comments
