### PR TITLE
Updated Kingfisher for the latest Xcode(14.3)

### DIFF
--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -9,8 +9,8 @@ import ProjectDescription
 
 let dependencies = Dependencies(
     swiftPackageManager: [
-        .remote(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", requirement: .upToNextMinor(from: "4.6.3")),
-        .remote(url: "https://github.com/onevcat/Kingfisher", requirement: .upToNextMinor(from: "7.2.0")),
+        .remote(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", requirement: .upToNextMinor(from: "4.9.5")),
+        .remote(url: "https://github.com/onevcat/Kingfisher", requirement: .upToNextMinor(from: "7.8.1")),
     ],
     platforms: [.iOS]
 )


### PR DESCRIPTION
# Summary
Kingfisher 7.2.0 does not build in Xcode 14.3. Updated dependencies to the latest version of Kingfisher. Additionally, updated the SendbirdChatSDK to the latest version.
