### PR TITLE
Fix message scrolling issues for open channel

### DIFF
--- a/Apps/AddExtraDataMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/AddExtraDataMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -171,6 +172,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -201,18 +207,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/AddStructuredDataMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/AddStructuredDataMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -169,6 +170,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -199,18 +205,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/BasicOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/BasicOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -169,6 +170,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -199,18 +205,29 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
-    private func scrollToFocusMessage() {
+    private func  scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard
+            let focusMessage = targetMessageForScrolling,
+            let messageIndex = messageListUseCase.messages.firstIndex(where: { $0.messageId == focusMessage.messageId })
+        else {
+            return
+        }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        let scrollPosition: UITableView.ScrollPosition = (
+            messageIndex == messageListUseCase.messages.count - 1
+        ) ? .bottom : .top
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/CategorizeMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/CategorizeMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -169,6 +170,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -199,18 +205,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/CategorizeWithCustomTypeOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/CategorizeWithCustomTypeOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -169,6 +170,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -199,18 +205,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/CopyMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/CopyMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -175,6 +176,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -232,18 +238,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/DeleteMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/DeleteMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -171,6 +172,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -201,18 +207,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/GenerateThumbnailForFileOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/GenerateThumbnailForFileOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -169,6 +170,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -199,18 +205,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/MentionUsersInMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/MentionUsersInMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -171,6 +172,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -201,18 +207,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/MessageThreadingOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/MessageThreadingOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -171,6 +172,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -201,18 +207,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/MetaDataCounterOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/MetaDataCounterOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -186,6 +187,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -216,18 +222,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/OpenGraphTagsOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/OpenGraphTagsOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -169,6 +170,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -199,18 +205,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/ReportMessageUserOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/ReportMessageUserOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -175,6 +176,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -225,18 +231,26 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
         
-        tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
+        
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/SendVariousTypesOfFileOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/SendVariousTypesOfFileOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -169,6 +170,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -199,18 +205,27 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
+        
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
         
         tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }

--- a/Apps/UpdateMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
+++ b/Apps/UpdateMessageOpenChannel/Sources/Channel/OpenChannelViewController.swift
@@ -37,6 +37,7 @@ class OpenChannelViewController: UIViewController {
     private weak var messageInputBottomConstraint: NSLayoutConstraint?
 
     var targetMessageForScrolling: BaseMessage?
+    private var isInitialLoad = true
     
     let channel: OpenChannel
     
@@ -171,6 +172,11 @@ extension OpenChannelViewController: UITableViewDelegate {
     
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if scrollView.contentOffset.y - Constant.loadMoreThreshold <= 0 {
+            if let visibleIndexPaths = tableView.indexPathsForVisibleRows,
+               let firstVisibleIndexPath = visibleIndexPaths.first,
+               firstVisibleIndexPath.row < messageListUseCase.messages.count {
+                targetMessageForScrolling = messageListUseCase.messages[firstVisibleIndexPath.row]
+            }
             messageListUseCase.loadPreviousMessages()
         }
          
@@ -201,18 +207,27 @@ extension OpenChannelViewController: OpenChannelMessageListUseCaseDelegate {
     
     func openChannelMessageListUseCase(_ useCase: OpenChannelMessageListUseCase, didUpdateMessages messages: [BaseMessage]) {
         tableView.reloadData()
+        if isInitialLoad && !messages.isEmpty {
+            targetMessageForScrolling = messages.last
+            isInitialLoad = false
+        }
         scrollToFocusMessage()
     }
     
     private func scrollToFocusMessage() {
         defer { self.targetMessageForScrolling = nil }
         
-        guard let focusMessage = targetMessageForScrolling,
-              focusMessage.messageId == messageListUseCase.messages.last?.messageId else { return }
+        guard let focusMessage = targetMessageForScrolling else { return }
         
-        let focusMessageIndexPath = IndexPath(row: messageListUseCase.messages.count - 1, section: 0)
+        guard let messageIndex = messageListUseCase.messages.firstIndex(where: { 
+            $0.messageId == focusMessage.messageId || $0.requestId == focusMessage.requestId 
+        }) else { return }
+        
+        let focusMessageIndexPath = IndexPath(row: messageIndex, section: 0)
         
         tableView.scrollToRow(at: focusMessageIndexPath, at: .bottom, animated: false)
+        let scrollPosition: UITableView.ScrollPosition = (messageIndex == messageListUseCase.messages.count - 1) ? .bottom : .top
+        tableView.scrollToRow(at: focusMessageIndexPath, at: scrollPosition, animated: false)
     }
 
 }


### PR DESCRIPTION
### Changed
- Modified to load only a specified number of messages instead of all messages when loading messages in open channels
- Fixed to show the latest messages first when entering an open channel
- Fixed scroll position not being reset when loading additional messages in open channels