### PR TITLE
[CLNP-8557] Migrate sample call sites to registerDevicePushTokenForMultiDevicePush

### DIFF
--- a/Apps/PushNotificationsGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
+++ b/Apps/PushNotificationsGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 
 class PushNotificationUseCase {
     func registerPushToken(deviceToken: Data) {
-        SendbirdChat.registerDevicePushToken(deviceToken) { status, error in
+        SendbirdChat.registerDevicePushTokenForMultiDevicePush(deviceToken) { status, error in
             if let error = error {
                 print("APNS registration failed. \(error)")
                 return
@@ -34,7 +34,7 @@ class PushNotificationUseCase {
         }
 
         if enable {
-            SendbirdChat.registerDevicePushToken(pushToken, completionHandler: { (status, error) in
+            SendbirdChat.registerDevicePushTokenForMultiDevicePush(pushToken, completionHandler: { (status, error) in
                 guard error == nil else {
                     // Handle error.
                     return

--- a/Apps/PushNotificationsGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
+++ b/Apps/PushNotificationsGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 
 class PushNotificationUseCase {
     func registerPushToken(deviceToken: Data) {
-        SendbirdChat.registerDevicePushToken(deviceToken, unique: true) { status, error in
+        SendbirdChat.registerDevicePushToken(deviceToken) { status, error in
             if let error = error {
                 print("APNS registration failed. \(error)")
                 return
@@ -34,7 +34,7 @@ class PushNotificationUseCase {
         }
 
         if enable {
-            SendbirdChat.registerDevicePushToken(pushToken, unique: true, completionHandler: { (status, error) in
+            SendbirdChat.registerDevicePushToken(pushToken, completionHandler: { (status, error) in
                 guard error == nil else {
                     // Handle error.
                     return

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 
 class PushNotificationUseCase {
     func registerPushToken(deviceToken: Data) {
-        SendbirdChat.registerDevicePushToken(deviceToken) { status, error in
+        SendbirdChat.registerDevicePushTokenForMultiDevicePush(deviceToken) { status, error in
             if let error = error {
                 print("APNS registration failed. \(error)")
                 return
@@ -34,7 +34,7 @@ class PushNotificationUseCase {
         }
 
         if enable {
-            SendbirdChat.registerDevicePushToken(pushToken, completionHandler: { (status, error) in
+            SendbirdChat.registerDevicePushTokenForMultiDevicePush(pushToken, completionHandler: { (status, error) in
                 guard error == nil else {
                     // Handle error.
                     return

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/PushNotificationUseCase.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 
 class PushNotificationUseCase {
     func registerPushToken(deviceToken: Data) {
-        SendbirdChat.registerDevicePushToken(deviceToken, unique: true) { status, error in
+        SendbirdChat.registerDevicePushToken(deviceToken) { status, error in
             if let error = error {
                 print("APNS registration failed. \(error)")
                 return
@@ -34,7 +34,7 @@ class PushNotificationUseCase {
         }
 
         if enable {
-            SendbirdChat.registerDevicePushToken(pushToken, unique: true, completionHandler: { (status, error) in
+            SendbirdChat.registerDevicePushToken(pushToken, completionHandler: { (status, error) in
                 guard error == nil else {
                     // Handle error.
                     return

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/UserConnectionUseCase.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/UserConnectionUseCase.swift
@@ -79,7 +79,7 @@ public class UserConnectionUseCase {
             return
         }
         
-        SendbirdChat.registerDevicePushToken(pushToken, unique: true) { status, error in
+        SendbirdChat.registerDevicePushToken(pushToken) { status, error in
             if let error = error {
                 print("APNS registration failed. \(error)")
                 return

--- a/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/UserConnectionUseCase.swift
+++ b/Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/UserConnectionUseCase.swift
@@ -79,7 +79,7 @@ public class UserConnectionUseCase {
             return
         }
         
-        SendbirdChat.registerDevicePushToken(pushToken) { status, error in
+        SendbirdChat.registerDevicePushTokenForMultiDevicePush(pushToken) { status, error in
             if let error = error {
                 print("APNS registration failed. \(error)")
                 return

--- a/Apps/UserDoNotDisturbSnooze/Sources/UseCase/PushNotificationUseCase.swift
+++ b/Apps/UserDoNotDisturbSnooze/Sources/UseCase/PushNotificationUseCase.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 
 class PushNotificationUseCase {
     func registerPushToken(deviceToken: Data) {
-        SendbirdChat.registerDevicePushToken(deviceToken) { status, error in
+        SendbirdChat.registerDevicePushTokenForMultiDevicePush(deviceToken) { status, error in
             if let error = error {
                 print("APNS registration failed. \(error)")
                 return
@@ -34,7 +34,7 @@ class PushNotificationUseCase {
         }
 
         if enable {
-            SendbirdChat.registerDevicePushToken(pushToken, completionHandler: { (status, error) in
+            SendbirdChat.registerDevicePushTokenForMultiDevicePush(pushToken, completionHandler: { (status, error) in
                 guard error == nil else {
                     // Handle error.
                     return

--- a/Apps/UserDoNotDisturbSnooze/Sources/UseCase/PushNotificationUseCase.swift
+++ b/Apps/UserDoNotDisturbSnooze/Sources/UseCase/PushNotificationUseCase.swift
@@ -11,7 +11,7 @@ import SendbirdChatSDK
 
 class PushNotificationUseCase {
     func registerPushToken(deviceToken: Data) {
-        SendbirdChat.registerDevicePushToken(deviceToken, unique: true) { status, error in
+        SendbirdChat.registerDevicePushToken(deviceToken) { status, error in
             if let error = error {
                 print("APNS registration failed. \(error)")
                 return
@@ -34,7 +34,7 @@ class PushNotificationUseCase {
         }
 
         if enable {
-            SendbirdChat.registerDevicePushToken(pushToken, unique: true, completionHandler: { (status, error) in
+            SendbirdChat.registerDevicePushToken(pushToken, completionHandler: { (status, error) in
                 guard error == nil else {
                     // Handle error.
                     return

--- a/Modules/CommonModule/Sources/UseCase/User/UserConnectionUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/User/UserConnectionUseCase.swift
@@ -68,7 +68,7 @@ public class UserConnectionUseCase {
             return
         }
         
-        SendbirdChat.registerDevicePushToken(pushToken, unique: true) { status, error in
+        SendbirdChat.registerDevicePushToken(pushToken) { status, error in
             if let error = error {
                 print("APNS registration failed. \(error)")
                 return

--- a/Modules/CommonModule/Sources/UseCase/User/UserConnectionUseCase.swift
+++ b/Modules/CommonModule/Sources/UseCase/User/UserConnectionUseCase.swift
@@ -68,7 +68,7 @@ public class UserConnectionUseCase {
             return
         }
         
-        SendbirdChat.registerDevicePushToken(pushToken) { status, error in
+        SendbirdChat.registerDevicePushTokenForMultiDevicePush(pushToken) { status, error in
             if let error = error {
                 print("APNS registration failed. \(error)")
                 return

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -9,7 +9,7 @@ import ProjectDescription
 
 let dependencies = Dependencies(
     swiftPackageManager: [
-        .remote(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", requirement: .exact("4.24.1")),
+        .remote(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", requirement: .exact("4.39.5")),
         .remote(url: "https://github.com/onevcat/Kingfisher", requirement: .exact("8.1.0")),
     ],
     platforms: [.iOS]


### PR DESCRIPTION
## Summary
Updates all 8 `SendbirdChat.registerDevicePushToken(_:unique:completionHandler:)` call sites across 5 sample apps to use the new `SendbirdChat.registerDevicePushTokenForMultiDevicePush(_:completionHandler:)` convenience method introduced in chat-ios PR #1745.

Behavior change: the previous call form `unique: true` is replaced by the new method, which is equivalent to `unique: false`. Multi-device push is the intended demonstration here — `unique: true` disables device-token local caching and was misleading in these reference samples.

## Why
- chat-ios is adding a `registerDevicePushTokenForMultiDevicePush(_:completionHandler:)` convenience method that registers the device token with multi-device push enabled (equivalent to `unique: false`): https://github.com/sendbird/chat-ios/pull/1745
- Calling with `unique: true` disables device-token local caching on the SDK side (`PushTokenRepository.swift` cache-hit branch is bypassed when `isUnique` is true).
- The new method's name explicitly documents the multi-device-push behavior at the call site, so customers reading the samples immediately understand what's happening.

## Why the rename (not a default-arg)?
Earlier iterations of chat-ios PR #1745 tried (1) `unique: Bool = false` default and (2) a no-`unique` arity-overloaded method. Both were rejected — the default-arg doesn't expose to Obj-C callers (Swift defaults are invisible to the generated Obj-C header), and the arity overload hid the semantic difference behind the same Swift name. The final v3 approach renames the method to `registerDevicePushTokenForMultiDevicePush` for explicit semantic naming.

## Caller behavior change
| Sample call (before this PR) | Sample call (after this PR) | Behavior change |
|---|---|---|
| `SendbirdChat.registerDevicePushToken(token, unique: true) { ... }` | `SendbirdChat.registerDevicePushTokenForMultiDevicePush(token) { ... }` | `unique: true` → `unique: false` (multi-device, cache-friendly) |

## Files
- `Apps/PushNotificationsGroupChannel/Sources/UseCase/PushNotificationUseCase.swift` (2 calls)
- `Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/PushNotificationUseCase.swift` (2 calls)
- `Apps/PushNotificationsTranslationGroupChannel/Sources/UseCase/UserConnectionUseCase.swift` (1 call)
- `Apps/UserDoNotDisturbSnooze/Sources/UseCase/PushNotificationUseCase.swift` (2 calls)
- `Modules/CommonModule/Sources/UseCase/User/UserConnectionUseCase.swift` (1 call)

## Status — Draft
This PR is in Draft until the chat-ios release that contains `registerDevicePushTokenForMultiDevicePush` ships and this repo's `SendbirdChatSDK` dependency is bumped to that version. Without the bump, the new method won't be available and the changed call sites would fail to compile against the currently-pinned SDK.

Sequence:
1. chat-ios PR #1745 merges
2. chat-ios releases (e.g. `4.40.0` or next minor)
3. Bump `SendbirdChatSDK` pin in this repo to the released version
4. Mark this PR Ready for Review

## Test plan
- [ ] After dependency bump: builds without errors against the new chat-ios
- [ ] Push notification flow still works in each affected sample app
- [ ] Code review

Jira: https://sendbird.atlassian.net/browse/CLNP-8557